### PR TITLE
02 feature class based styling

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Add the `--continuous-rounding` property to any element:
 Requires browsers that support the CSS Paint API (Houdini).
 Modern versions of Chrome, Edge, and Opera are supported.
 
-## Example
+## Examples
 
 ```html
 
@@ -46,17 +46,34 @@ Modern versions of Chrome, Edge, and Opera are supported.
     This box will have smooth continuous corners
 </div>
 
+
 <div class="my-box" style="--continuous-rounding: 75px;
                            --continuous-rounding-bottom-left: 0;
                            --continuous-rounding-bottom-right: 0;">
     This box will have smooth continuous corners only on the top side
 </div>
 
+
 <div class="my-box" style="--continuous-rounding-top-left: 10px;
                            --continuous-rounding-top-right: 50vw;
                            --continuous-rounding-bottom-right: 100px;
                            --continuous-rounding-bottom-left: 150px;">
     This box will have complete custom smooth continuous corners</span>
+</div>
+
+
+<!-- Example to use the library not via style="" but within CSS classes -->
+<style>
+    .my-custom-box {
+        /* your other class styles go here */
+        --continuous-rounding-top-left: 50px;
+        --continuous-rounding-bottom-left: 50px;
+    }
+</style>
+
+<!-- the .continuous-rounding class has to be attached to the element, too -->
+<div class="my-custom-box continuous-rounding">
+    This box will have continuous corners defined in my__class
 </div>
 ```
 

--- a/continuous-rounding.css
+++ b/continuous-rounding.css
@@ -28,12 +28,11 @@
     initial-value: none;
 }
 
-*[style*="--continuous-rounding"] {
+*[style*="--continuous-rounding"],
+.continuous-rounding {
     -webkit-mask-image: paint(continuous-corner);
     mask-image: paint(continuous-corner);
-}
-
-.rectangle[style*="--continuous-rounding"] {
-    -webkit-mask-image: paint(continuous-corner);
-    mask-image: paint(continuous-corner);
+    -webkit-mask-size: 100% 100%;
+    mask-size: 100% 100%;
+    mask-repeat: no-repeat;
 }

--- a/continuous-rounding.css
+++ b/continuous-rounding.css
@@ -1,31 +1,31 @@
 @property --continuous-rounding {
     syntax: '<length>';
-    inherits: true;
-    initial-value: 10px;
+    inherits: false;
+    initial-value: 0px;
 }
 
 @property --continuous-rounding-top-left {
-    syntax: '<length>';
-    inherits: true;
-    initial-value: 10px;
+    syntax: '<length> | none';
+    inherits: false;
+    initial-value: none;
 }
 
 @property --continuous-rounding-top-right {
-    syntax: '<length>';
-    inherits: true;
-    initial-value: 10px;
+    syntax: '<length> | none';
+    inherits: false;
+    initial-value: none;
 }
 
 @property --continuous-rounding-bottom-right {
-    syntax: '<length>';
-    inherits: true;
-    initial-value: 10px;
+    syntax: '<length> | none';
+    inherits: false;
+    initial-value: none;
 }
 
 @property --continuous-rounding-bottom-left {
-    syntax: '<length>';
-    inherits: true;
-    initial-value: 10px;
+    syntax: '<length> | none';
+    inherits: false;
+    initial-value: none;
 }
 
 *[style*="--continuous-rounding"] {

--- a/demo.html
+++ b/demo.html
@@ -127,9 +127,9 @@
     </div>
 
     <div class="demo-item">
-        <div class="rectangle" style="--continuous-rounding: 10rem;
-                                      --continuous-rounding-bottom-right: 0;
-                                      --continuous-rounding-bottom-left: 0;">
+        <div class="rectangle" style="--continuous-rounding: 15rem;
+                                      --continuous-rounding-bottom-right: 0px;
+                                      --continuous-rounding-bottom-left: 0px;">
             <div class="label">
                 <span>200 × 200</span>
                 <span class="radius-value">omit corners</span>
@@ -145,6 +145,26 @@
             <div class="label">
                 <span>200 × 200</span>
                 <span class="radius-value">complete custom corners</span>
+            </div>
+        </div>
+    </div>
+
+    <style>
+        /* Example to use the library within CSS classes */
+
+        .my__class {
+        /* your other class styles go here */
+        /* the .continuous-rounding class must be attached to the element, too */
+        --continuous-rounding-top-left: 50px;
+        --continuous-rounding-bottom-left: 50px;
+        }
+    </style>
+
+    <div class="demo-item">
+        <div class="rectangle continuous-rounding my__class">
+            <div class="label">
+                <span>200 × 200</span>
+                <span class="radius-value">class based styling</span>
             </div>
         </div>
     </div>


### PR DESCRIPTION
-- As I am pretty new to making pull requests, I don't know if I did this the correct way.
I made a new branch and pull request, the number corresponding to the issue #2 --

I have a lot of elements that shall get continuous corners. They are styled via their respective CSS classes (in BEM style).

I managed to add continuous corners to a specific CSS class instead of hardcoding it via style="" by changing the CSS of the library slightly, when adding the base modifier styles not only to `*[style*="--continuous-rounding"]` but also to a new class called `.continuous-rounding`

```html
*[style*="--continuous-rounding"],
.continuous-rounding {
    -webkit-mask-image: paint(continuous-corner);
    mask-image: paint(continuous-corner);
    -webkit-mask-size: 100% 100%;
    mask-size: 100% 100%;
    mask-repeat: no-repeat;
}
```

In order to make it work, we have to add the continuous-rounding class to an element (e.g. a `<div>`) that has to be styled with continuous corners. Now we can easily add `--continuous-rounding: 10px;` or any custom configuration to an identyfier class of this element.